### PR TITLE
[refactor] Expose constants

### DIFF
--- a/static/js/index.js
+++ b/static/js/index.js
@@ -3,9 +3,7 @@ var _ = require('ep_etherpad-lite/static/js/underscore');
 var cssFiles = ['ep_font_color/static/css/color.css'];
 
 var api = require('./api');
-
-var FONT_COLOR_ATTRIB_KEY = 'font-color';
-var BLACK_COLOR = 'A0';
+var utils = require('./utils');
 
 exports.postAceInit = function(hook, context) {
   api.init(context.ace);
@@ -16,8 +14,8 @@ exports.aceAttribsToClasses = function(hook, context) {
   var value = context.value;
 
   // black color is the same as not applying color
-  if (key === FONT_COLOR_ATTRIB_KEY && value !== BLACK_COLOR) {
-    return [FONT_COLOR_ATTRIB_KEY + '-' + value];
+  if (key === utils.FONT_COLOR_ATTRIB_KEY && value !== utils.BLACK_COLOR) {
+    return [utils.FONT_COLOR_ATTRIB_KEY + '-' + value];
   }
 };
 
@@ -28,7 +26,7 @@ function doInsertColors(colorName) {
     return;
   }
 
-  var new_color = [FONT_COLOR_ATTRIB_KEY, colorName]; // e.g. [ 'font-color' , 'A1' ]
+  var new_color = [utils.FONT_COLOR_ATTRIB_KEY, colorName]; // e.g. [ 'font-color' , 'A1' ]
   documentAttributeManager.setAttributesOnRange(rep.selStart, rep.selEnd, [new_color]);
 }
 

--- a/static/js/utils.js
+++ b/static/js/utils.js
@@ -1,0 +1,3 @@
+exports.FONT_COLOR_ATTRIB_KEY = 'font-color';
+exports.BLACK_COLOR = 'A0';
+exports.RED_COLOR = 'A1';


### PR DESCRIPTION
We expose some constants that are used on ep_script_scene_marks.
This is required by
https://github.com/storytouch/ep_script_scene_marks/pull/51
This is related to this [card](https://trello.com/c/UE4SckSa/1509-p3-criar-varredura-autom%C3%A1tica-toda-vez-que-abre-o-documento-pra-transformar-elementos-estranhos-em-action)