### PR TITLE
[feat] Use a specific font color to mark errors on text

### DIFF
--- a/static/css/color.css
+++ b/static/css/color.css
@@ -1,3 +1,5 @@
+/* use a different class to mark errors on pad, but works just like A1 (red) */
+.font-color-ERROR,
 .font-color-A1  { color: #FF0000; }
 .font-color-A2  { color: #FF7E00; }
 .font-color-A3  { color: #FFCC00; }

--- a/static/js/shared.js
+++ b/static/js/shared.js
@@ -1,23 +1,6 @@
-var collectContentPre = function(hook, context) {
+exports.collectContentPre = function(hook, context) {
   var fontColor = /(?:^| )font-color-([A-Za-z0-9]*)/.exec(context.cls);
   if (fontColor && fontColor[1]) {
     context.cc.doAttrib(context.state, 'font-color::' + fontColor[1]); // e.g. 'font-color::A1'
   }
-};
-
-// TODO: remove it
-var collectContentPost = function(hook, context) {
-  /*
-  var tname = context.tname;
-  var state = context.state;
-  var lineAttributes = state.lineAttributes
-  var tagIndex = _.indexOf(colors, tname);
-
-  if(tagIndex >= 0){
-    delete lineAttributes['color'];
-  }
-*/
-};
-
-exports.collectContentPre = collectContentPre;
-exports.collectContentPost = collectContentPost;
+}

--- a/static/js/utils.js
+++ b/static/js/utils.js
@@ -1,3 +1,3 @@
 exports.FONT_COLOR_ATTRIB_KEY = 'font-color';
 exports.BLACK_COLOR = 'A0';
-exports.RED_COLOR = 'A1';
+exports.ERROR_COLOR = 'ERROR';


### PR DESCRIPTION
Avoid confusion between a regular text marked with red color, and a text marked with error. Create a special font color to be used whenever the pad has any error on its content.

Implement part of https://trello.com/c/lkb6ypkA/1605.

This PR is part of the set of PRs:

- https://github.com/storytouch/ep_script_scene_marks/pull/58
- https://github.com/storytouch/ep_font_color/pull/4
- https://github.com/storytouch/ep_scene_navigator/pull/12