### PR TITLE
[fix] Export colors attributes to HTML

### DIFF
--- a/exportHTML.js
+++ b/exportHTML.js
@@ -16,7 +16,7 @@ function findAllColorUsedOn(pad) {
   var colors_used = [];
 
   pad.pool.eachAttrib(function(key, value){
-    if (key === "color") {
+    if (key === "font-color" && value != "A0") { // skip black (A0) color
       colors_used.push(value);
     }
   });
@@ -27,7 +27,7 @@ function findAllColorUsedOn(pad) {
 // Transforms an array of color names into color tags like ["color", "red"]
 function transformColorsIntoTags(color_names) {
   return _.map(color_names, function(color_name) {
-    return ["color", color_name];
+    return ["font-color", color_name];
   });
 }
 
@@ -55,5 +55,5 @@ function rewriteLine(context){
 
 // Change from <span data-color:x  to <span class:color:x
 function replaceDataByClass(text) {
-  return text.replace(/data-color=["|']([0-9a-zA-Z]+)["|']/gi, "class='color:$1'");
+  return text.replace(/data-font-color=["|']([0-9a-zA-Z]+)["|']/gi, "class='font-color-$1'");
 }

--- a/static/tests/backend/specs/api/exportHTML.js
+++ b/static/tests/backend/specs/api/exportHTML.js
@@ -209,16 +209,16 @@ var buildHTML = function(body) {
 var textWithColor = function(color, text) {
   if (!text) text = "this is " + color;
 
-  return "<span class='color:" + color + "'>" + text + "</span>";
+  return "<span class='font-color:" + color + "'>" + text + "</span>";
 }
 
 var regexWithColor = function(color, text) {
   if (!text) text = "this is " + color;
 
-  var regex = "<span .*class=['|\"].*color:" + color + ".*['|\"].*>" + text + "<\/span>";
+  var regex = "<span .*class=['|\"].*font-color:" + color + ".*['|\"].*>" + text + "<\/span>";
   // bug fix: if no other plugin on the Etherpad instance returns a value on getLineHTMLForExport() hook,
   // data-color=(...) won't be replaced by class=color:(...), so we need a fallback regex
-  var fallbackRegex = "<span .*data-color=['|\"]" + color + "['|\"].*>" + text + "<\/span>";
+  var fallbackRegex = "<span .*data-font-color=['|\"]" + color + "['|\"].*>" + text + "<\/span>";
 
   return regex + " || " + fallbackRegex;
 }


### PR DESCRIPTION
This PR fixes the exporting of color attributes to HTML, which allows accessing the color of the text in the output HTML provided by the export API.

Implements part of the [card 2237](https://trello.com/c/FrbBtWRx).