### PR TITLE
[fix] Fixes colors export

### DIFF
--- a/exportHTML.js
+++ b/exportHTML.js
@@ -4,11 +4,10 @@ var _ = require('ep_etherpad-lite/static/js/underscore');
 var colors = ['black', 'red', 'green', 'blue', 'yellow', 'orange'];
 
 // Add the props to be supported in export
-exports.exportHtmlAdditionalTagsWithData = function(hook, pad, cb){
-  var colors_used = findAllColorUsedOn(pad);
-  var tags = transformColorsIntoTags(colors_used);
-
-  cb(tags);
+exports.exportHtmlAdditionalTagsWithData = async function(hook, pad) {
+  var colorsUsed = findAllColorUsedOn(pad);
+  var tags = transformColorsIntoTags(colorsUsed);
+  return tags;
 };
 
 // Iterate over pad attributes to find only the color ones

--- a/static/tests/backend/specs/api/exportHTML.js
+++ b/static/tests/backend/specs/api/exportHTML.js
@@ -209,17 +209,17 @@ var buildHTML = function(body) {
 var textWithColor = function(color, text) {
   if (!text) text = "this is " + color;
 
-  return "<span class='font-color:" + color + "'>" + text + "</span>";
+  return "<span class='font-color-" + color + "'>" + text + "</span>";
 }
 
 var regexWithColor = function(color, text) {
   if (!text) text = "this is " + color;
 
-  var regex = "<span .*class=['|\"].*font-color:" + color + ".*['|\"].*>" + text + "<\/span>";
+  var regex = "<span .*class=['|\"].*font-color-" + color + ".*['|\"].*>" + text + "<\/span>";
   // bug fix: if no other plugin on the Etherpad instance returns a value on getLineHTMLForExport() hook,
   // data-color=(...) won't be replaced by class=color:(...), so we need a fallback regex
   var fallbackRegex = "<span .*data-font-color=['|\"]" + color + "['|\"].*>" + text + "<\/span>";
 
-  return regex + " || " + fallbackRegex;
+  return regex + "|" + fallbackRegex;
 }
 


### PR DESCRIPTION
This commit changes the `exportHtmlAdditionalTagsWithData` hook signature to `async`, which is the new Etherpad pattern.

It also fixes its backend tests that were resulting in false positives.

It is related to the [card 2550](https://trello.com/c/LMdmDlJe).